### PR TITLE
Setting default scan interval/window to 0x10.

### DIFF
--- a/src/max_ble_hci/data_params.py
+++ b/src/max_ble_hci/data_params.py
@@ -103,10 +103,10 @@ class ScanParams:
     scan_type: int = 0x1
     """Scan type."""
 
-    scan_interval: int = 0x100
+    scan_interval: int = 0x10
     """Scan interval."""
 
-    scan_window: int = 0x100
+    scan_window: int = 0x10
     """Scan duration."""
 
     addr_type: AddrType = AddrType.PUBLIC
@@ -132,10 +132,10 @@ class ConnParams:
     peer_addr: int
     """Connectable peer device address."""
 
-    scan_interval: int = 0x100
+    scan_interval: int = 0x10
     """Scan interval."""
 
-    scan_window: int = 0x100
+    scan_window: int = 0x10
     """Scan duration."""
 
     init_filter_policy: int = 0x0

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -109,7 +109,7 @@ logger.addHandler(console_handler)
 EXIT_FUNC_MAGIC = 999
 DEFAULT_BAUD = 115200
 DEFAULT_ADV_INTERVAL = 0x60
-DEFAULT_SCAN_INTERVAL = 0x100
+DEFAULT_SCAN_INTERVAL = 0x10
 DEFAULT_CONN_INTERVAL = 0x6  # 7.5 ms
 DEFAULT_SUP_TIMEOUT = 0x64  # 1 s
 
@@ -359,7 +359,7 @@ def main():
         dest="scan_interval",
         type=_hex_int,
         default=DEFAULT_SCAN_INTERVAL,
-        help=f"""Scanning interval in units of 0.625 ms, 16-bit hex number 0x0020 - 0x4000.
+        help=f"""Scanning interval in units of 0.625 ms, 16-bit hex number 0x0004 - 0x4000.
         Default: 0x{DEFAULT_SCAN_INTERVAL}""",
     )
     scan_parser.set_defaults(

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -179,7 +179,7 @@ def main():
         description=cli_description, formatter_class=RawTextHelpFormatter
     )
 
-    parser.add_argument("--version", action="version", version="%(prog)s 1.1.3")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.1.4")
 
     parser.add_argument("serial_port", help="Serial port path or COM#")
     parser.add_argument(


### PR DESCRIPTION
No impact to scanning performance, minor change to reflect default values in specification. This will cause the scanner to switch channels more often. 

![image](https://github.com/Analog-Devices-MSDK/MAX-BLE-HCI/assets/54692400/410f6245-b960-4136-a9ba-7d32eb3fbc4b)