### PR TITLE
feat(HCI): Support the TX Test V4 command

### DIFF
--- a/src/max_ble_hci/ble_standard_cmds.py
+++ b/src/max_ble_hci/ble_standard_cmds.py
@@ -650,7 +650,7 @@ class BleStandardCmds:
             return self.send_le_controller_command(
                 OCF.LE_CONTROLLER.ENHANCED_TRANSMITTER_TEST, params=params
             )
-        elif mode == TxTestMode.V4.value:
+        if mode == TxTestMode.V4.value:
             # Angle of Arrival (AOA) is not needed, so no switch pattern will be provided
             switch_pattern_len = 0
             params = [
@@ -661,14 +661,13 @@ class BleStandardCmds:
                 cte_len,
                 cte_type,
                 switch_pattern_len,
-                power
+                power,
             ]
 
             return self.send_le_controller_command(
                 OCF.LE_CONTROLLER.TRANSMITTER_TEST_V4, params=params
             )
-
-
+        return None
 
     def rx_test(
         self,

--- a/src/max_ble_hci/ble_standard_cmds.py
+++ b/src/max_ble_hci/ble_standard_cmds.py
@@ -605,6 +605,8 @@ class BleStandardCmds:
 
         Parameters
         ----------
+        mode: Union[TxTestMode, int]
+            The test and set of parameters to be transmitted.
         channel : int, optional
             The channel on which transmission should take place.
         phy : Union[PhyOption,int], optional
@@ -613,6 +615,16 @@ class BleStandardCmds:
             The packet payload type that should be used.
         packet_len : int, optional
             The desired length of the transmitted packets.
+        cte_len: int
+            CTE length measureed in units of 8 micro-seconds.
+        cte_type: Union[CteType, int]
+            A CTE type for Angle of Arrival (AoA) selection.
+        switch_pattern_len: Union[SwitchPatternLen, int]
+            The number of transmitter antennas to be used
+        switch_pattern: int
+            The ID of the transmitter antenna
+        power: Union[TxPower, str]
+            The transmitter power level.
 
         Returns
         -------

--- a/src/max_ble_hci/ble_standard_cmds.py
+++ b/src/max_ble_hci/ble_standard_cmds.py
@@ -57,7 +57,7 @@ from typing import List, Optional, Tuple, Union, Callable
 
 from ._hci_logger import get_formatted_logger
 from ._transport import SerialUartTransport
-from .constants import PayloadOption, PhyOption
+from .constants import PayloadOption, PhyOption, TxTestMode, CteType, SwitchPatternLen, TxPower
 from .data_params import AdvParams, ConnParams, EstablishConnParams, ScanParams
 from .hci_packets import CommandPacket, EventPacket
 from .packet_codes import EventMask, EventMaskPage2, EventMaskLE, StatusCode
@@ -587,10 +587,16 @@ class BleStandardCmds:
 
     def tx_test(
         self,
+        mode: Union[TxTestMode, int] = TxTestMode.ENHANCED,
         channel: int = 0,
         phy: Union[PhyOption, int] = PhyOption.PHY_1M,
         payload: Union[PayloadOption, int] = PayloadOption.PLD_PRBS9,
         packet_len: int = 0,
+        cte_len: int = 0,
+        cte_type: Union[CteType, int] = CteType.AOA,
+        switch_pattern_len: Union[SwitchPatternLen, str] = SwitchPatternLen.MIN,
+        switch_pattern: int = 0,
+        power: Union[TxPower, str] = TxPower.MAX,
     ) -> StatusCode:
         """Start a transmitter test.
 
@@ -615,15 +621,39 @@ class BleStandardCmds:
 
         """
 
+        if isinstance(mode, TxTestMode):
+            mode = mode.value
         if isinstance(payload, PayloadOption):
             payload = payload.value
         if isinstance(phy, PhyOption):
             phy = phy.value
+        if isinstance(cte_type, CteType):
+            cte_type = cte_type.value
+        
+        if isinstance(switch_pattern_len, SwitchPatternLen):
+            switch_pattern_len = switch_pattern_len.value
+        if isinstance(switch_pattern_len, str):            
+            switch_pattern_len = SwitchPatternLen.str_to_mask(switch_pattern_len)
 
-        params = [channel, packet_len, payload, phy]
-        return self.send_le_controller_command(
-            OCF.LE_CONTROLLER.ENHANCED_TRANSMITTER_TEST, params=params
-        )
+        if isinstance(power, TxPower):
+            power = power.value
+        if isinstance(power, str):
+            power = TxPower.str_to_mask(power)
+
+        
+
+        if mode == TxTestMode.ENHANCED.value:
+            params = [channel, packet_len, payload, phy]
+            return self.send_le_controller_command(
+                OCF.LE_CONTROLLER.ENHANCED_TRANSMITTER_TEST, params=params
+            )
+        elif mode == TxTestMode.V4.value:
+            params = [channel, packet_len, payload, phy, cte_len, cte_type, switch_pattern_len, switch_pattern, power]
+            return self.send_le_controller_command(
+                OCF.LE_CONTROLLER.TRANSMITTER_TEST_V4, params=params
+            )
+
+        
 
     def rx_test(
         self,

--- a/src/max_ble_hci/constants.py
+++ b/src/max_ble_hci/constants.py
@@ -244,3 +244,58 @@ class PubKeyValidateMode(Enum):
 
     ALT2 = 0x1
     """ALT2 validation mode."""
+
+
+class TxTestMode(Enum):
+
+    ENHANCED = 1
+
+    V3 = 3
+
+    V4 = 4
+
+class CteType(Enum):
+    """Requested CTE Types"""
+
+    AOA = 0
+    """AoA Constant Tone Extension"""     
+    AOD_1_US = 1
+    """AoD Constant Tone Extension with 1 us slots"""
+    AOD_2_US = 2
+    """AoD Constant Tone Extension with 2 us slots"""
+
+class SwitchPatternLen(Enum):
+
+    MIN = 0x02
+
+    MAX = 0x4B
+
+    @staticmethod
+    def str_to_mask(option: str) -> int:
+        option = option.lower()
+
+        if option == "min":
+            return SwitchPatternLen.MIN.value
+
+        if option == "max":
+            return SwitchPatternLen.MAX.value
+
+        return SwitchPatternLen.MIN.value
+    
+class TxPower(Enum):
+
+    MAX = 0x7F
+
+    MIN = 0x7E
+
+    @staticmethod
+    def str_to_mask(option: str) -> int:
+        option = option.lower()
+
+        if option == "max":
+            return TxPower.MAX.value
+
+        if option == "min":
+            return TxPower.MIN.value
+
+        return TxPower.MAX.value

--- a/src/max_ble_hci/constants.py
+++ b/src/max_ble_hci/constants.py
@@ -258,15 +258,17 @@ class TxTestMode(Enum):
     V4 = 4
     """Transmitter Test V4"""
 
+
 class CteType(Enum):
     """Requested CTE Types"""
 
     AOA = 0
-    """AoA Constant Tone Extension"""     
+    """AoA Constant Tone Extension"""
     AOD_1_US = 1
     """AoD Constant Tone Extension with 1 us slots"""
     AOD_2_US = 2
     """AoD Constant Tone Extension with 2 us slots"""
+
 
 class TxPower(Enum):
     """Transmitter Power Levels"""
@@ -280,7 +282,7 @@ class TxPower(Enum):
     @staticmethod
     def str_to_mask(option: str) -> int:
         """Select a power level.
-        
+
         Parameters
         ----------
         option: str

--- a/src/max_ble_hci/constants.py
+++ b/src/max_ble_hci/constants.py
@@ -247,6 +247,7 @@ class PubKeyValidateMode(Enum):
 
 
 class TxTestMode(Enum):
+    """Transmitter Test Modes"""
 
     ENHANCED = 1
     """Transmitter Test Enhanced"""
@@ -267,27 +268,8 @@ class CteType(Enum):
     AOD_2_US = 2
     """AoD Constant Tone Extension with 2 us slots"""
 
-class SwitchPatternLen(Enum):
-
-    MIN = 0x02
-    """Switching pattern minimum length"""
-
-    MAX = 0x4B
-    """Switching pattern maximum length"""
-
-    @staticmethod
-    def str_to_mask(option: str) -> int:
-        option = option.lower()
-
-        if option == "min":
-            return SwitchPatternLen.MIN.value
-
-        if option == "max":
-            return SwitchPatternLen.MAX.value
-
-        return SwitchPatternLen.MIN.value
-    
 class TxPower(Enum):
+    """Transmitter Power Levels"""
 
     MAX = 0x7F
     """Maximum power level"""
@@ -297,6 +279,18 @@ class TxPower(Enum):
 
     @staticmethod
     def str_to_mask(option: str) -> int:
+        """Select a power level.
+        
+        Parameters
+        ----------
+        option: str
+            The desired power level.
+
+        Returns
+        -------
+        int
+            The power level's corresponding power symbol.
+        """
         option = option.lower()
 
         if option == "max":

--- a/src/max_ble_hci/constants.py
+++ b/src/max_ble_hci/constants.py
@@ -249,10 +249,13 @@ class PubKeyValidateMode(Enum):
 class TxTestMode(Enum):
 
     ENHANCED = 1
+    """Transmitter Test Enhanced"""
 
     V3 = 3
+    """Transmitter Test V4"""
 
     V4 = 4
+    """Transmitter Test V4"""
 
 class CteType(Enum):
     """Requested CTE Types"""
@@ -267,8 +270,10 @@ class CteType(Enum):
 class SwitchPatternLen(Enum):
 
     MIN = 0x02
+    """Switching pattern minimum length"""
 
     MAX = 0x4B
+    """Switching pattern maximum length"""
 
     @staticmethod
     def str_to_mask(option: str) -> int:
@@ -285,8 +290,10 @@ class SwitchPatternLen(Enum):
 class TxPower(Enum):
 
     MAX = 0x7F
+    """Maximum power level"""
 
     MIN = 0x7E
+    """Minimum power level"""
 
     @staticmethod
     def str_to_mask(option: str) -> int:

--- a/src/max_ble_hci/packet_defs.py
+++ b/src/max_ble_hci/packet_defs.py
@@ -561,6 +561,9 @@ class LEControllerOCF(Enum):
     SET_TX_POWER_REPORT_ENABLE = 0x7A
     """Set TX power reporting enable command."""
 
+    TRANSMITTER_TEST_V4 = 0x7B
+    """Transmitter test version3 command."""
+
     SET_DATA_RELATED_ADDRESS_CHANGES = 0x7C
     """Set data related address changes command."""
 

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -816,7 +816,7 @@ Default: {hex(DEFAULT_CE_LEN)}""",
          1: Enhanced
          3: V3
          4: V4
-         Default: Enhanced"""
+         Default: Enhanced""",
     )
     tx_test_parser.add_argument(
         "-c",

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -75,7 +75,11 @@ from argparse import RawTextHelpFormatter
 from colorlog import ColoredFormatter
 
 from max_ble_hci import BleHci
-from max_ble_hci.constants import PayloadOption, PhyOption, AddrType
+from max_ble_hci.constants import (
+    PayloadOption,
+    PhyOption,
+    AddrType,
+)
 from max_ble_hci.data_params import (
     AdvParams,
     EstablishConnParams,
@@ -804,6 +808,17 @@ Default: {hex(DEFAULT_CE_LEN)}""",
         formatter_class=RawTextHelpFormatter,
     )
     tx_test_parser.add_argument(
+        "-m",
+        "--mode",
+        type=int,
+        default=1,
+        help="""Tx test mode.
+         1: Enhanced
+         3: V3
+         4: V4
+         Default: Enhanced"""
+    )
+    tx_test_parser.add_argument(
         "-c",
         "--channel",
         type=int,
@@ -847,14 +862,57 @@ Default: {hex(DEFAULT_CE_LEN)}""",
         default=0,
         help="Tx packet length, number of bytes per packet, 0-255. Default: 0",
     )
+    tx_test_parser.add_argument(
+        "-cl",
+        "--cte-length",
+        type=int,
+        default=0,
+        help="CTE length, 0-255. Default: 0",
+    )
+    tx_test_parser.add_argument(
+        "-ct",
+        "--cte-type",
+        type=int,
+        default=0,
+        help="""CTE length
+        0: AOA
+        1: AOA with 1 us slots
+        2: AOA with 2 us slots
+        Default: AOA""",
+    )
+    tx_test_parser.add_argument(
+        "--switch-pattern-length",
+        nargs="?",
+        choices=("min", "MIN", "max", "MAX"),
+        default="min",
+        help="""Set the switch pattern length
+        min: 0x02
+        max: 0x4B
+        Default: min""",
+    )
+    tx_test_parser.add_argument(
+        "--power",
+        nargs="?",
+        choices=("min", "MIN", "max", "MAX"),
+        default="max",
+        help="""Set the Tx power level
+        min: 0x7F
+        max: 0x7E
+        Default: max""",
+    )
 
     tx_test_parser.set_defaults(
         func=lambda args: print(
             hci.tx_test(
+                mode=args.mode,
                 channel=args.channel,
                 phy=PhyOption(args.phy),
                 payload=PayloadOption(args.payload),
                 packet_len=args.packet_length,
+                cte_len=args.cte_length,
+                cte_type=args.cte_type,
+                switch_pattern_len=args.switch_pattern_length,
+                power=args.power,
             )
         ),
     )

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -881,16 +881,6 @@ Default: {hex(DEFAULT_CE_LEN)}""",
         Default: AOA""",
     )
     tx_test_parser.add_argument(
-        "--switch-pattern-length",
-        nargs="?",
-        choices=("min", "MIN", "max", "MAX"),
-        default="min",
-        help="""Set the switch pattern length
-        min: 0x02
-        max: 0x4B
-        Default: min""",
-    )
-    tx_test_parser.add_argument(
         "--power",
         nargs="?",
         choices=("min", "MIN", "max", "MAX"),
@@ -911,7 +901,6 @@ Default: {hex(DEFAULT_CE_LEN)}""",
                 packet_len=args.packet_length,
                 cte_len=args.cte_length,
                 cte_type=args.cte_type,
-                switch_pattern_len=args.switch_pattern_length,
                 power=args.power,
             )
         ),


### PR DESCRIPTION
### Description

Extend the `tx_test()` function to support the V4 test.

To use, use the following command in the HCI tool: `tx-test -m 4` or `tx-test --mode 4`

