### PR TITLE
Add Function Generator Command for continuous pattern generation

### DIFF
--- a/src/max_ble_hci/constants.py
+++ b/src/max_ble_hci/constants.py
@@ -173,7 +173,7 @@ class PhyOption(Enum):
 
 
 class PayloadOption(Enum):
-    """BLE-definded payload options."""
+    """BLE-defined payload options."""
 
     PLD_PRBS9 = 0
     """PRBS9 payload option."""
@@ -198,6 +198,25 @@ class PayloadOption(Enum):
 
     PLD_01010101 = 7
     """01010101 payload option."""
+
+
+class PatternOption(Enum):
+    """Vendor-Specific Function Generator Pattern options."""
+
+    PT_CW = 0
+    """Carrier Wave pattern option."""
+
+    PT_PRBS9 = 1
+    """PRBS9 pattern option."""
+
+    PT_PRBS15 = 2
+    """PRBS15 pattern option."""
+
+    PT_DF1 = 3
+    """DF1 pattern option."""
+
+    PT_DF2 = 4
+    """DF2 pattern option."""
 
 
 class AddrType(Enum):

--- a/src/max_ble_hci/vendor_spec_cmds.py
+++ b/src/max_ble_hci/vendor_spec_cmds.py
@@ -553,8 +553,8 @@ class VendorSpecificCmds:
         enable : int
             1 to enable function generator, 0 to disable.
         channel : int
-            The on pattern should be transmitted. This will be mapped to the frequency in kHz
-            which will be passed to the controller
+            The channel on which the pattern should be transmitted. This will
+            be mapped to the frequency in kHz which will be passed to the controller
         pattern_type : Union[PatternOption, int]
             The pattern type that should be transmitted.
 

--- a/src/max_ble_hci/vendor_spec_cmds.py
+++ b/src/max_ble_hci/vendor_spec_cmds.py
@@ -62,6 +62,7 @@ from .constants import (
     MAX_U64,
     PayloadOption,
     PhyOption,
+    PatternOption,
     PubKeyValidateMode,
     BtTxPacketType,
 )
@@ -534,6 +535,62 @@ class VendorSpecificCmds:
         params = [channel, phy, modulation_idx]
         params.extend(to_le_nbyte_list(num_packets, 2))
         return self.send_vs_command(OCF.VENDOR_SPEC.RX_TEST, params=params)
+
+    def tx_fgen_vs(
+        self,
+        enable: int = 1,
+        channel: int = 0,
+        pattern_type: Union[PatternOption, int] = PatternOption.PT_CW,
+    ) -> StatusCode:
+        """Start a vendor-specific function generator transmitter test.
+
+        Sends a vendor-specific command to the DUT, telling it to
+        start/stop continuously transmitting a pattern type in accordance
+        with the given parameters.
+
+        Parameters
+        ----------
+        enable : int
+            1 to enable function generator, 0 to disable.
+        channel : int
+            The on pattern should be transmitted. This will be mapped to the frequency in kHz
+            which will be passed to the controller
+        pattern_type : Union[PatternOption, int]
+            The pattern type that should be transmitted.
+
+        Returns
+        -------
+        StatusCode
+            The return packet status code.
+
+        Raises
+        ------
+        ValueError
+            If `enable` is greater than 1 or less than 0.
+        ValueError
+            If `channel` is greater than 39 or less than 0.
+        ValueError
+            If `pattern_type` is greater than 4 or less than 0.
+
+        """
+        if not 0 <= enable <= 1:
+            raise ValueError(f"Enable is an invalid option({enable}), must be 1 or 0.")
+        if not 0 <= channel < 40:
+            raise ValueError(
+                f"Channel out of bandwidth ({channel}), must be in range [0, 40)."
+            )
+
+        pattern_type = (
+            pattern_type.value
+            if isinstance(pattern_type, PatternOption)
+            else pattern_type
+        )
+
+        # the controller expects a frequency to be passed in, map channel to frequency in kHz
+        frequency_khz = 2402000 + (channel * 2000)
+
+        params = [enable, frequency_khz, pattern_type]
+        return self.send_vs_command(OCF.VENDOR_SPEC.FGEN, params=params)
 
     def reset_test_stats(self) -> StatusCode:
         """Reset accumulated test stats.

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -1588,14 +1588,6 @@ Default: {hex(DEFAULT_CE_LEN)}""",
     flush_parser = subparsers.add_parser("flush", help="Flush serial port")
     flush_parser.set_defaults(func=lambda _: hci.port.flush())
 
-    def _script_runner(script_path):
-        print(script_path)
-        with open(script_path, "r", encoding="utf-8") as script:
-            commands = script.readlines()
-
-        if commands:
-            _run_input_cmds(commands, terminal)
-
     run_parser = subparsers.add_parser(
         "run",
         help="run command via os",

--- a/src/max_ble_hci_cli.py
+++ b/src/max_ble_hci_cli.py
@@ -78,6 +78,7 @@ from max_ble_hci import BleHci
 from max_ble_hci.constants import (
     PayloadOption,
     PhyOption,
+    PatternOption,
     AddrType,
 )
 from max_ble_hci.data_params import (
@@ -1162,6 +1163,60 @@ Default: {hex(DEFAULT_CE_LEN)}""",
                 phy=PhyOption(args.phy),
                 modulation_idx=args.modulationIdx,
                 num_packets=args.num_packets,
+            )
+        ),
+    )
+
+    #### TX_FGEN_VS PARSER ####
+
+    tx_fgen_vs_parser = subparsers.add_parser(
+        "tx-fgen-vs",
+        aliases=["fgen"],
+        help="Execute the vendor-specific function generator",
+        formatter_class=RawTextHelpFormatter,
+    )
+    tx_fgen_vs_parser.add_argument(
+        "-e",
+        "--enable",
+        dest="enable",
+        type=int,
+        default=1,
+        help="Enable or disable Function Generator. Default: 1 (enable)",
+    )
+    tx_fgen_vs_parser.add_argument(
+        "-c",
+        "--channel",
+        dest="channel",
+        type=int,
+        default=0,
+        help="""
+        Channel to transmit continuous function generation on
+        Default: 0
+        Range: 0-39
+        """,
+    )
+    tx_fgen_vs_parser.add_argument(
+        "-p",
+        "--pattern-type",
+        dest="pattern_type",
+        type=int,
+        default=0,
+        help="""
+        Vendor-specific Pattern Type to transmit
+        0: Carrier Wave
+        1: PRBS9
+        2: PRBS15
+        3: DF1
+        4: DF2
+        Default: Carrier Wave
+        """,
+    )
+    tx_fgen_vs_parser.set_defaults(
+        func=lambda args: print(
+            hci.tx_fgen_vs(
+                enable=args.enable,
+                channel=args.channel,
+                pattern_type=PatternOption(args.pattern_type),
             )
         ),
     )


### PR DESCRIPTION
This feature is implemented to fulfill the request to have a way to transmit an unmodulated carrier wave.